### PR TITLE
Add `deploy` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Fetch, build, and run the OpenSwarm.
 
+For help, use `swarmake [command] --help`.
+
 ## Examples
 The Atlas simulation project:
 ```bash

--- a/swarmake/cmd.py
+++ b/swarmake/cmd.py
@@ -7,17 +7,63 @@ from itertools import cycle
 from swarmake.logger import setup_logging, LOGGER
 logging = LOGGER.bind(context=__name__)  # Bind initial context (__name__)
 
-def execute_command(command, project_name, force_show_output=False):
+
+def execute(command, tag=None, directory=None):
     """
-    Execute the specified command for the project.
+    Just execute the specified command, and return the return code.
+    """
+    executed, stdout, stderr = execute_and_output(command, tag, directory)
+    return executed
+
+def execute_and_output(command, tag=None, directory=None):
+    """
+    Just execute the specified command, and return the return code.
+    """
+    # Bind the tag to the logger context
+    logger = logging.bind(tag=tag)
+
+    if command:
+        if directory:
+            command = f"cd {directory} && {command}"
+
+        # Log the command execution start
+        logger.debug(f"Executing command: \n\n\t{command}\n\n")
+
+        # Start timer
+        start_time = datetime.now()
+
+        # Capture output and wait for the process to finish
+        process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = process.communicate()
+
+        elapsed_time = round((datetime.now() - start_time).total_seconds(), 3)
+
+        if process.returncode != 0:
+            logger.error(f"Command failed for tag {tag}", error=stderr.decode())
+            return False, stdout.decode(), stderr.decode()
+        else:
+            logger.debug(f"Completed with status {process.returncode} in {elapsed_time} s")
+
+        return process.returncode == 0, stdout.decode(), stderr.decode()
+    else:
+        logger.debug(f"No command specified")
+        return False, "", ""
+
+
+def execute_pretty(command, tag=None, force_show_output=False, is_interactive=False):
+    """
+    Execute the specified command for the project, displaying a spinner and elapsed time.
 
     Display a spinner and a timer for the command execution only when stderr is redirected.
     """
-    # Bind the project_name to the logger context
-    logger = logging.bind(project=project_name)
+    # Bind the tag to the logger context
+    logger = logging.bind(project=tag)
 
     # Check if stderr is interactive (not redirected)
-    stderr_is_interactive = sys.stderr.isatty()
+     # FIXME the passed parameter is_interactive is not having the expected effect
+    is_interactive = is_interactive or sys.stderr.isatty()
+
+    is_ok = False
 
     if command:
         # Log the command execution start
@@ -26,23 +72,23 @@ def execute_command(command, project_name, force_show_output=False):
         # Start timer
         start_time = datetime.now()
 
-        if stderr_is_interactive:
+        if is_interactive:
             # In interactive mode, let stdout/stderr be passed directly to the terminal
             process = subprocess.Popen(command, shell=True)
         else:
             # In non-interactive mode, capture stdout and stderr
             process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        spinner_cycle = cycle(['|', '/', '-', '\\']) if not stderr_is_interactive else None
+        spinner_cycle = cycle(['|', '/', '-', '\\']) if not is_interactive else None
         try:
             # Display a spinner and elapsed time while the process runs if not interactive
             while process.poll() is None:
                 # Calculate elapsed time
                 elapsed_time = datetime.now() - start_time
-                if not stderr_is_interactive:
+                if not is_interactive:
                     # Update spinner and time display only if stderr is redirected
                     spinner = next(spinner_cycle)
-                    sys.stdout.write(f"\r{spinner} Running {project_name}... Time elapsed: {str(elapsed_time).split('.')[0]} ")
+                    sys.stdout.write(f"\r{spinner} Running {tag}... Time elapsed: {str(elapsed_time).split('.')[0]} ")
                     sys.stdout.flush()
                 time.sleep(0.1)  # Pause to simulate spinner speed
 
@@ -52,12 +98,13 @@ def execute_command(command, project_name, force_show_output=False):
             elapsed_time = round(elapsed_time.total_seconds(), 3)
 
             # If we're in interactive mode, we don't need to show stdout/stderr, it goes directly to the terminal.
-            if stderr_is_interactive:
+            if is_interactive:
 
                 if process.returncode != 0:
                     logger.error(f"Command failed")
-                    raise RuntimeError(f"Command failed for project {project_name}")
+                    raise RuntimeError(f"Command failed {tag}")
                 else:
+                    is_ok = True
                     logger.debug(f"Completed ok in {elapsed_time} s")
             else:
                 # # Capture output and wait for the process to finish
@@ -66,15 +113,17 @@ def execute_command(command, project_name, force_show_output=False):
                 if process.returncode != 0:
                     sys.stdout.write("\r \n")  # Clean up the spinner line
                     logger.error(f"Command failed", error=stderr.decode())
-                    raise RuntimeError(f"Command failed for project {project_name}")
+                    raise RuntimeError(f"Command failed {tag}")
                 else:
+                    is_ok = True
                     sys.stdout.write(f"\r✔ Completed             \n") # extra spaces to overwrite spinner line
                     logger.debug(f"Completed ok in {elapsed_time} s")
                     if force_show_output:
                         sys.stdout.write(stdout.decode())  # Output the command's stdout
-
         finally:
-            if not stderr_is_interactive:
+            if not is_interactive:
                 sys.stdout.write("\n")  # Ensure newline after command execution ends
     else:
         logger.debug(f"No command specified")
+
+    return is_ok

--- a/swarmake/main.py
+++ b/swarmake/main.py
@@ -53,7 +53,7 @@ def main(ctx):
     setup_logging("swarmake.log", log_level, ["console", "file"])
 
 
-def build(project_name, clean_build_first, is_interactive=False):
+def do_build(project_name, clean_build_first, is_interactive=False):
     """Build the specified project"""
 
     print("\n\n================================================================================")
@@ -84,8 +84,8 @@ def build(project_name, clean_build_first, is_interactive=False):
 @main.command()
 @click.option('-c', '--clean-build-first', default=False, is_flag=True, help="Clean the build directory before building")
 @click.argument("project_name")
-def build_command(project_name, clean_build_first):
-    return build(project_name, clean_build_first)
+def build(project_name, clean_build_first):
+    return do_build(project_name, clean_build_first)
 
 
 @main.command()
@@ -135,9 +135,9 @@ def deploy(firmware_name):
 
     # if needed, build dotbot and swarmit projects
     if not cmd.execute(dotbot_project.list_outputs_cmd, directory=dotbot_project.build_dir):
-        build("dotbot", clean_build_first=False, is_interactive=False)
+        do_build("dotbot", clean_build_first=False, is_interactive=False)
     if not os.path.exists("build/swarmit"):
-        build("swarmit", clean_build_first=False, is_interactive=False)
+        do_build("swarmit", clean_build_first=False, is_interactive=False)
 
     # use swarmit to check the available devices
     res, stdout, stderr = cmd.execute_and_output("swarmit status")

--- a/swarmake/swarmake.toml
+++ b/swarmake/swarmake.toml
@@ -1,8 +1,14 @@
 
 [projects.dotbot]
 repo = "DotBot-firmware" # if the project name is different from the repo name
-build = "BUILD_TARGET=dotbot-v2 BUILD_CONFIG=Debug DOCKER_TARGETS=03app_dotbot make docker"
-list-outputs = "ls -l projects/03app_dotbot/Output/dotbot-v2/Debug/Exe"
+build = """
+BUILD_TARGET=dotbot-v2 BUILD_CONFIG=Debug DOCKER_TARGETS="swarmit_move swarmit_motors" make docker
+# BUILD_TARGET=dotbot-v2 BUILD_CONFIG=Debug DOCKER_TARGETS="swarmit_move" make docker
+"""
+list-outputs = """
+ls -l swarmit/move/Output/dotbot-v2/Debug/Exe
+ls -l swarmit/motors/Output/dotbot-v2/Debug/Exe
+"""
 
 [projects.pydotbot]
 repo = "PyDotBot"


### PR DESCRIPTION
Calling this:

```
swarmake deploy move
```

Will:
1. clone and build / install the dotbot and swarmit projects
2. use swarmit to deploy the `move` sample firmware to one or more dotbots

Note that it assumes an existing infrastructure of dotbots configured with swarmit netcore and bootloader applications.